### PR TITLE
Handle extreme numbers in the Roll command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -108,7 +108,13 @@ async def joined(ctx):
 @bot.command(pass_context=True)
 async def roll(ctx, arg1=1, arg2=100):
     "You can specify the amount of type of dice with a space, else it will be a random num between 1-100"
+    await ctx.message.add_reaction('\U0001F3B2')
+    if type(arg1) is not int or type(arg2) is not int:
+        return
     author = ctx.message.author
+    if arg1 > 100 or arg2 > 100:
+        await ctx.send('Woah %s, your rolls are too powerful' % (author))
+        return
     message = ""
     summ = 0
     for i in range(arg1):
@@ -120,7 +126,6 @@ async def roll(ctx, arg1=1, arg2=100):
         await ctx.send('Woah %s, your rolls are too powerful' % (author))
     else:
         await ctx.send('%s' % (message))
-    await ctx.message.add_reaction('\U0001F3B2')
 
 @bot.command(hidden=True)
 @commands.has_any_role('Cody', 'Dallas')

--- a/bot.py
+++ b/bot.py
@@ -115,6 +115,10 @@ async def roll(ctx, arg1=1, arg2=100):
     if arg1 > 100 or arg2 > 100:
         await ctx.send('Woah %s, your rolls are too powerful' % (author))
         return
+    elif arg1 < 1 or arg2 < 0:
+        await ctx.send('Woah %s, your rolls are not powerful enough' % (author))
+        return
+
     message = ""
     summ = 0
     for i in range(arg1):


### PR DESCRIPTION
We had a couple of issues where the bot would display some unintended behavior if the numbers presented were negative, and would genuinely freeze if the numbers were too large.

This very primitively solves the issues by just checking the arguments and spitting a message if it wouldn't be able to gracefully handle it.