### PR TITLE
Roll no longer pings people

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -112,6 +112,10 @@ async def roll(ctx, arg1="1", arg2="100"):
     "You can specify the amount of dice with a space or delimited with a 'd', else it will be 2 random nums between 1-6"
     await ctx.message.add_reaction('\U0001F3B2')
     author = ctx.message.author.display_name
+
+    #Make sure author won't send pings to people
+    author = author.replace("@", "[@]")
+
     sum_dice = 0
     message = ""
     arg1 = str(arg1).lower()


### PR DESCRIPTION
If a user had their name as at everyone, it would attempt to ping everyone. This edit should force it to change "@" to "[@]"