### PR TITLE
Use modern credential providers, add formatting, use f-strings over % formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 ### This bot is a continuing project and I welcome pull requests that improve/fix or add features
 
 * Feel free to take the code and create your own bot to host.
-* One thing to note is that I created a file called token1.py to keep my token in with a function def stringToken(): that just returns the token string. I added that to the .gitignore because discord will make the token no longer work if it finds it on the internet.
+* Uses a `.env` file to define the bot token. Syntax is `TOKEN=<discord bot token here>`
 * Originally created by AguilarJoel, jameswhowell, and CodeMastr3 on March 7, 2020.

--- a/bot.py
+++ b/bot.py
@@ -5,7 +5,6 @@ import ast
 import requests
 import os
 
-
 from datetime import datetime
 from dotenv import load_dotenv
 from random import seed
@@ -17,12 +16,14 @@ load_dotenv('.env')
 
 bot = commands.Bot(command_prefix='!')
 
+
 @bot.command()
 async def ping(ctx):
     """
     Returns pong
     """
     await ctx.send('pong')
+
 
 @bot.command()
 async def say(ctx, *, arg):
@@ -31,10 +32,12 @@ async def say(ctx, *, arg):
     """
     await ctx.send(arg)
 
+
 @bot.command(hidden=True)
 async def secret(ctx, *, arg):
     await ctx.send(arg)
     await ctx.message.delete()
+
 
 messageDict = emojiRole.message
 with open('roles.txt', 'r') as f:
@@ -55,6 +58,7 @@ with open('dict.txt', 'r') as f:
 
 emojiList = {}
 
+
 @bot.command()
 @commands.has_any_role('Cody', 'Dallas')
 async def addMessage(ctx):
@@ -64,7 +68,7 @@ async def addMessage(ctx):
     global messageDict
     global watched_message
     global emojiList
-    for mess,emolist in messageDict.items():
+    for mess, emolist in messageDict.items():
         reacted_message = await ctx.send(mess)
         watched_message[reacted_message.id] = emolist
         f = open("dict.txt", "w")
@@ -72,6 +76,7 @@ async def addMessage(ctx):
         f.close()
         for emo in emolist:
             await reacted_message.add_reaction(emo)
+
 
 @bot.command()
 async def myroles(ctx):
@@ -83,9 +88,10 @@ async def myroles(ctx):
     iterroles = iter(member.roles)
     next(iterroles)
     for role in iterroles:
-        s+=role.name
-        s+="\n"
-    await ctx.send('Your roles:\n%s' %s)
+        s += role.name
+        s += "\n"
+    await ctx.send(f"Your roles:\n{s}")
+
 
 @bot.command()
 async def serverroles(ctx):
@@ -100,9 +106,10 @@ async def serverroles(ctx):
         if role.name == "hackbot 1.1":
             break
         else:
-            s+=role.name
-            s+="\n"
-    await ctx.send('Servers roles:\n%s' %s)
+            s += role.name
+            s += "\n"
+    await ctx.send('Servers roles:\n%s' % s)
+
 
 """
 @bot.command()
@@ -114,13 +121,17 @@ async def poll(ctx, *arg):
         #await ctx.message.add_reaction('\U0001F3B2')
 """
 
+
 @bot.command()
 async def joined(ctx):
     """
     Tells you when you joined the server using UTC
     """
     member = ctx.author
-    await ctx.send('Time %s joined %s in UTC:\n%s' %(member.mention, ctx.guild.name, member.joined_at))
+    await ctx.send(
+        f"Time {member.mention} joined {ctx.guild.name} in UTC:\n{member.joined_at}"
+    )
+
 
 @bot.command(pass_context=True)
 async def roll(ctx, arg1="1", arg2="100"):
@@ -137,22 +148,22 @@ async def roll(ctx, arg1="1", arg2="100"):
     message = ""
     arg1 = str(arg1).lower()
 
-    if("d" in arg1):
+    if ("d" in arg1):
         arg1, arg2 = arg1.split("d", 1)
-        if(arg1 == ""):
+        if (arg1 == ""):
             arg1 = "1"
-        if(arg2 == ""):
+        if (arg2 == ""):
             await ctx.send(f"Woah {author}, your rolls are too powerful")
-            return;
+            return
 
-    if(not arg1.isdecimal() or not str(arg2).isdecimal()):
+    if (not arg1.isdecimal() or not str(arg2).isdecimal()):
         await ctx.send(f"Woah {author}, your rolls are too powerful")
         return
 
     arg1 = int(arg1)
     arg2 = int(arg2)
 
-    if(arg1 > 100 or arg2 > 100):
+    if (arg1 > 100 or arg2 > 100):
         await ctx.send(f"Woah {author}, your rolls are too powerful")
         return
     elif arg1 < 1 or arg2 < 1:
@@ -160,26 +171,29 @@ async def roll(ctx, arg1="1", arg2="100"):
         return
 
     # Is it possible to be *too* pythonic?
-    message += (f"{author} rolled {arg1} d{arg2}{(chr(39) + 's') if arg1 != 1 else ''}\n")
+    message += (
+        f"{author} rolled {arg1} d{arg2}{(chr(39) + 's') if arg1 != 1 else ''}\n"
+    )
     # Never.
 
     message += ("\n")
-    for i in range(1, arg1+1):
+    for i in range(1, arg1 + 1):
         roll = randint(1, arg2)
         sum_dice += roll
-        if(arg2 == 20 and roll == 20):
+        if (arg2 == 20 and roll == 20):
             message += (f"Roll {i}: {roll} - Critical Success! (20)\n")
-        elif(arg2 == 20 and roll == 1):
+        elif (arg2 == 20 and roll == 1):
             message += (f"Roll {i}: {roll} - Critical Failure! (1)\n")
         else:
             message += (f"Roll {i}: {roll}\n")
 
     message += ("\n")
     message += (f"Sum of all rolls: {sum_dice}\n")
-    if(len(message) >= 2000):
+    if (len(message) >= 2000):
         await ctx.send(f"Woah {author}, your rolls are too powerful")
     else:
         await ctx.send(message)
+
 
 @bot.command(hidden=True)
 @commands.has_any_role('Cody', 'Dallas')
@@ -189,9 +203,11 @@ async def logout(ctx):
     """
     await bot.logout()
 
+
 @bot.command()
 async def escalate(ctx):
     await ctx.send('ESCALATING')
+
 
 def normalize_location(loc):
     """
@@ -199,8 +215,13 @@ def normalize_location(loc):
     Will change a phrase like "uNITED sTATES" to "United States" since all location are stored as proper nouns
     """
     arr = [i.lower() for i in loc.split(' ')]
-    arr =[''.join([word[i] if i != 0 else word[i].upper() for i in range(len(word))]) for word in arr]
+    arr = [
+        ''.join(
+            [word[i] if i != 0 else word[i].upper() for i in range(len(word))])
+        for word in arr
+    ]
     return ' '.join(arr)
+
 
 def gll(js, loc):
     """
@@ -214,18 +235,18 @@ def gll(js, loc):
 
 
 @bot.command()
-async def vaccines(ctx, loc = "United States"):
+async def vaccines(ctx, loc="United States"):
     """
     Uses the information available at howmanyvaccinated.com to state how many people have been vaccinated based off location
     Will default to United States
     """
     url = "https://www.howmanyvaccinated.com/vaccine"
-    page = requests.get(url);
+    page = requests.get(url)
     js = page.json()
 
     #Make sure that the location has every chance to succeed without fuzzy finding
     loc = normalize_location(loc)
-    dat = gll(js,loc)
+    dat = gll(js, loc)
     msg = ""
     if dat is not None:
         #Format the number with commas to make it easier to read
@@ -240,6 +261,7 @@ async def vaccines(ctx, loc = "United States"):
 async def logout_error(ctx, error):
     await ctx.channel.send("You don't have the permission to run that command")
 
+
 @bot.command(pass_context=True)
 async def sub(ctx, *args):
     """
@@ -247,7 +269,7 @@ async def sub(ctx, *args):
     """
     member = ctx.author
     for arg in args:
-        if(arg == "all"):
+        if (arg == "all"):
             roles = ctx.guild.roles
             iterroles = iter(roles)
             next(iterroles)
@@ -260,18 +282,24 @@ async def sub(ctx, *args):
         else:
             role = discord.utils.get(ctx.guild.roles, name=arg)
             await member.remove_roles(role)
-    await ctx.send('I\'ve removed your requested roles %s!' %member.mention)
+    await ctx.send(f"I\'ve removed your requested roles {member.mention}!")
+
 
 @sub.error
 async def sub_error(ctx, error):
-    await ctx.channel.send("You have probably typed a role that doesn't exist please make sure that isn't the case and try again")
+    await ctx.channel.send(
+        "You have probably typed a role that doesn't exist please make sure that isn't the case and try again"
+    )
+
 
 @bot.command(pass_context=True)
 async def add(ctx, *args):
-    """Adds any roles mentioned after add if they exist say all for all roles possible to add"""
+    """
+    Adds any roles mentioned after add if they exist say all for all roles possible to add
+    """
     member = ctx.author
     for arg in args:
-        if(arg == "all"):
+        if (arg == "all"):
             roles = ctx.guild.roles
             iterroles = iter(roles)
             next(iterroles)
@@ -284,11 +312,15 @@ async def add(ctx, *args):
         else:
             role = discord.utils.get(ctx.guild.roles, name=arg)
             await member.add_roles(role)
-    await ctx.send('I\'ve added your new roles %s!' %member.mention)
+    await ctx.send(f"I've added your new roles {member.mention}!")
+
 
 @add.error
 async def add_error(ctx, error):
-    await ctx.channel.send("You have probably typed a role that doesn't exist please make sure that isn't the case and try again")
+    await ctx.channel.send(
+        "You have probably typed a role that doesn't exist please make sure that isn't the case and try again"
+    )
+
 
 async def manage_reactions(payload, added: bool):
     if not payload.message_id in watched_message:
@@ -298,9 +330,9 @@ async def manage_reactions(payload, added: bool):
     mapping = watched_message[messageID]
 
     if not payload.emoji.name in mapping:
-    # reaction.emoji is str if normal emoji or ID if custom, but we use both as keys in mapping
+        # reaction.emoji is str if normal emoji or ID if custom, but we use both as keys in mapping
         return
-    
+
     guildName = bot.get_guild(payload.guild_id)
     member = discord.utils.get(guildName.members, id=payload.user_id)
     role = discord.utils.get(guildName.roles, name=mapping[payload.emoji.name])
@@ -310,18 +342,26 @@ async def manage_reactions(payload, added: bool):
     else:
         await member.remove_roles(role)
 
+
 @bot.event
 async def on_member_join(member):
     botChannel = discord.utils.get(member.guild.channels, name='bot-stuff')
-    rulesChannel = discord.utils.get(member.guild.channels, name='rules-and-info')
-    await botChannel.send('Welcome to the server %s!\nPlease check out %s!\nIn order to view channels you need to add the relevant roles. Type !help for help, !serverroles for the roles you can add yourself to, !add "role1" "role2" to put yourself in that course.' %(member.mention, rulesChannel.mention))
+    rulesChannel = discord.utils.get(member.guild.channels,
+                                     name='rules-and-info')
+    await botChannel.send((
+        f'Welcome to the server {member.mention}!\nPlease check out {rulesChannel.mention}!\nIn order to view channels you need to add the relevant roles.\
+        Type !help for help, !serverroles for the roles you can add yourself to, !add "role1" "role2" to put yourself in that course.'
+    ))
+
 
 @bot.event
 async def on_raw_reaction_add(payload):
     await manage_reactions(payload, True)
 
+
 @bot.event
 async def on_raw_reaction_remove(payload):
     await manage_reactions(payload, False)
+
 
 bot.run(os.getenv('TOKEN'))

--- a/bot.py
+++ b/bot.py
@@ -139,10 +139,7 @@ async def roll(ctx, arg1="1", arg2="100"):
     You can specify the amount of dice with a space or delimited with a 'd', else it will be 2 random nums between 1-6
     """
     await ctx.message.add_reaction('\U0001F3B2')
-    author = ctx.message.author.display_name
-
-    #Make sure author won't send pings to people
-    author = author.replace("@", "[@]")
+    author = ctx.message.author.mention  # use mention string to avoid pinging other people
 
     sum_dice = 0
     message = ""

--- a/bot.py
+++ b/bot.py
@@ -1,18 +1,19 @@
 import discord
 import discord.utils
 import emojiRole
+import token1 as token
 import ast
 import requests
-import os
+# import os
 
 from datetime import datetime
-from dotenv import load_dotenv
+# from dotenv import load_dotenv
 from random import seed
 from random import randint
 from discord.ext import commands
 
 seed(datetime.now())
-load_dotenv('.env')
+# load_dotenv('.env')
 
 bot = commands.Bot(command_prefix='!')
 
@@ -361,4 +362,5 @@ async def on_raw_reaction_remove(payload):
     await manage_reactions(payload, False)
 
 
-bot.run(os.getenv('TOKEN'))
+# bot.run(os.getenv('TOKEN'))
+bot.run(token.stringToken())

--- a/bot.py
+++ b/bot.py
@@ -1,27 +1,34 @@
 import discord
 import discord.utils
 import emojiRole
-import token1 as token
 import ast
 import requests
+import os
+
 
 from datetime import datetime
+from dotenv import load_dotenv
 from random import seed
 from random import randint
 from discord.ext import commands
 
 seed(datetime.now())
+load_dotenv('.env')
 
 bot = commands.Bot(command_prefix='!')
 
 @bot.command()
 async def ping(ctx):
-    "Returns pong"
+    """
+    Returns pong
+    """
     await ctx.send('pong')
 
 @bot.command()
 async def say(ctx, *, arg):
-    "Says what you put"
+    """
+    Says what you put
+    """
     await ctx.send(arg)
 
 @bot.command(hidden=True)
@@ -51,7 +58,9 @@ emojiList = {}
 @bot.command()
 @commands.has_any_role('Cody', 'Dallas')
 async def addMessage(ctx):
-    "Adds the Role Messages"
+    """
+    Adds the Role Messages
+    """
     global messageDict
     global watched_message
     global emojiList
@@ -66,7 +75,9 @@ async def addMessage(ctx):
 
 @bot.command()
 async def myroles(ctx):
-    "Lists roles of member that called this function"
+    """
+    Lists roles of member that called this function
+    """
     member = ctx.author
     s = ""
     iterroles = iter(member.roles)
@@ -78,7 +89,9 @@ async def myroles(ctx):
 
 @bot.command()
 async def serverroles(ctx):
-    "Lists roles of the server"
+    """
+    Lists roles of the server
+    """
     s = ""
     roles = ctx.guild.roles
     iterroles = iter(roles)
@@ -103,13 +116,17 @@ async def poll(ctx, *arg):
 
 @bot.command()
 async def joined(ctx):
-    "Tells you when you joined the server using UTC"
+    """
+    Tells you when you joined the server using UTC
+    """
     member = ctx.author
     await ctx.send('Time %s joined %s in UTC:\n%s' %(member.mention, ctx.guild.name, member.joined_at))
 
 @bot.command(pass_context=True)
 async def roll(ctx, arg1="1", arg2="100"):
-    "You can specify the amount of dice with a space or delimited with a 'd', else it will be 2 random nums between 1-6"
+    """
+    You can specify the amount of dice with a space or delimited with a 'd', else it will be 2 random nums between 1-6
+    """
     await ctx.message.add_reaction('\U0001F3B2')
     author = ctx.message.author.display_name
 
@@ -167,7 +184,9 @@ async def roll(ctx, arg1="1", arg2="100"):
 @bot.command(hidden=True)
 @commands.has_any_role('Cody', 'Dallas')
 async def logout(ctx):
-    "Logs the bot out"
+    """
+    Logs the bot out
+    """
     await bot.logout()
 
 @bot.command()
@@ -223,7 +242,9 @@ async def logout_error(ctx, error):
 
 @bot.command(pass_context=True)
 async def sub(ctx, *args):
-    "Subtracts any roles mentioned after sub if they exist say all for all possible roles to remove"
+    """
+    Subtracts any roles mentioned after sub if they exist say all for all possible roles to remove
+    """
     member = ctx.author
     for arg in args:
         if(arg == "all"):
@@ -247,7 +268,7 @@ async def sub_error(ctx, error):
 
 @bot.command(pass_context=True)
 async def add(ctx, *args):
-    "Adds any roles mentioned after add if they exist say all for all roles possible to add"
+    """Adds any roles mentioned after add if they exist say all for all roles possible to add"""
     member = ctx.author
     for arg in args:
         if(arg == "all"):
@@ -303,4 +324,4 @@ async def on_raw_reaction_add(payload):
 async def on_raw_reaction_remove(payload):
     await manage_reactions(payload, False)
 
-bot.run(token.stringToken())
+bot.run(os.getenv('TOKEN'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp==3.6.3
 async-timeout==3.0.1
 attrs==20.3.0
+black==20.8b1 
 certifi==2020.12.5
 chardet==3.0.4
 discord==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ certifi==2020.12.5
 chardet==3.0.4
 discord==1.0.1
 discord.py==1.5.1
+python-dotenv==0.15.0 
 idna==2.10
 idna-ssl==1.1.0
 multidict==4.7.6


### PR DESCRIPTION
Open to input on this PR as it includes a number of very opinionated changes.

Changes:

- add "[black](https://black.readthedocs.io/en/stable/)" formatter 
- use f-strings instead of % formatting in bot.py
- use discord.py functionality to escape certain names in !roll command
- use a .env file to provide credentials to the bot

The last change will affect the workflow. To adapt, simply add a **.env** file in the same directory as **bot.py** with the syntax "TOKEN=<bot token here>"
".env" files are already included in ".gitignore"
