### PR TITLE
Updates the serverroles command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -237,19 +237,18 @@ async def myroles(ctx):
 @bot.command()
 async def serverroles(ctx):
     """
-    Lists roles of the server
+    Lists the roles that this bot can add you to
+    To add any role(s) to yourself, please view !add and !sub
     """
-    s = ""
-    roles = ctx.guild.roles
-    iterroles = iter(roles)
-    next(iterroles)
-    for role in iterroles:
-        if role.name == "hackbot 1.1":
+    validRoles = []
+    roles = ctx.guild.roles[1:] #Strip @everyone
+    stopRole = bot.user.name #Everything below bot's name's role is ommitted
+    bs = "\n" #bs stands for "Backslash" but it's bs i can't do a \n in {} for f-strings
+    for role in roles:
+        if role.name == stopRole:
             break
-        else:
-            s += role.name
-            s += "\n"
-    await ctx.send('Servers roles:\n%s' % s)
+        validRoles += [role.name]
+    await ctx.send(f"Server's Roles:{bs}{bs}{bs.join(validRoles[::-1])}")
 
 
 """

--- a/bot.py
+++ b/bot.py
@@ -240,15 +240,9 @@ async def serverroles(ctx):
     Lists the roles that this bot can add you to
     To add any role(s) to yourself, please view !add and !sub
     """
-    validRoles = []
-    roles = ctx.guild.roles[1:] #Strip @everyone
-    stopRole = bot.user.name #Everything below bot's name's role is ommitted
+    roles = bot_roles(ctx)
     bs = "\n" #bs stands for "Backslash" but it's bs i can't do a \n in {} for f-strings
-    for role in roles:
-        if role.name == stopRole:
-            break
-        validRoles += [role.name]
-    await ctx.send(f"Server's Roles:{bs}{bs}{bs.join(validRoles[::-1])}")
+    await ctx.send(f"Server's Roles:{bs}{bs}{bs.join([i.name for i in roles])}")
 
 
 """
@@ -548,6 +542,18 @@ def has_role(ctx, role):
     roles = [i.name for i in list(member.roles)]
     return role.name in roles
 
+#Gets all the roles the bot can configure
+def bot_roles(ctx):
+    validRoles = []
+    roles = ctx.guild.roles[1:] #Strip @everyone
+    stopRole = bot.user.name #Everything below bot's name's role is ommitted
+    for role in roles:
+        if role.name == stopRole:
+            break
+        if not role.name.startswith("|---"): #Preamble for organization
+            validRoles += [role]
+    return validRoles[::-1]
+
 #Add roles for a user
 @bot.command(pass_context=True)
 async def add(ctx, *args):
@@ -560,19 +566,33 @@ async def add(ctx, *args):
     r_fail = []
     r_had = []
     member = ctx.author
+    br = bot_roles(ctx)
 
-    #Attempt to add users roles
-    for arg in args:
-        role = discord.utils.get(ctx.guild.roles, name=arg)
-        try:
-            #Check if user already had role
+    if "all" in args:
+        for role in br:
             if not has_role(ctx, role):
-                await member.add_roles(role)
-                r_success += [arg]
+                try:
+                    await member.add_roles(role)
+                    r_success += [role.name]
+                except:
+                    pass #Don't care about extraneous roles
+    else:
+        #Attempt to add users roles
+        for arg in args:
+            role = discord.utils.get(ctx.guild.roles, name=arg)
+            if role not in br: #Check if it's an accepted role first
+                r_fail += [arg]
+
             else:
-                r_had += [arg]
-        except:
-            r_fail += [arg]
+                try:
+                    #Check if user already had role
+                    if not has_role(ctx, role):
+                        await member.add_roles(role)
+                        r_success += [arg]
+                    else:
+                        r_had += [arg]
+                except:
+                    r_fail += [arg]
 
     msg = ""
     if r_success:
@@ -583,6 +603,9 @@ async def add(ctx, *args):
         msg += f"I have failed to add the role(s): {' '.join(r_fail)}\n"
     if r_fail:
         msg += "Please use !serverroles to check available roles and spelling\n"
+
+    if not msg:
+        msg = "I did nothing"
 
     #Message back to user
     await ctx.send(f"{member.mention}:\n{msg}")
@@ -599,17 +622,31 @@ async def sub(ctx, *args):
     r_fail = []
     r_had = []
     member = ctx.author
-    for arg in args:
-        role = discord.utils.get(ctx.guild.roles, name=arg)
-        try:
-            #Check if user didn't already have role
+    br = bot_roles(ctx)
+    if "all" in args:
+        for role in bot_roles(ctx):
             if has_role(ctx, role):
-                await member.remove_roles(role)
-                r_success += [arg]
+                try:
+                    await member.remove_roles(role)
+                    r_success += [role.name]
+                except:
+                    pass #Don't care about extraneous roles
+    else:
+        for arg in args:
+            role = discord.utils.get(ctx.guild.roles, name=arg)
+            if role not in br: #Check if it's an accepted role first
+                r_fail += [arg]
+
             else:
-                r_had += [arg]
-        except:
-            r_fail += [arg]
+                try:
+                    #Check if user didn't already have role
+                    if has_role(ctx, role):
+                        await member.remove_roles(role)
+                        r_success += [arg]
+                    else:
+                        r_had += [arg]
+                except:
+                    r_fail += [arg]
 
     msg = ""
     if r_success:
@@ -620,6 +657,9 @@ async def sub(ctx, *args):
         msg += f"I have failed to remove the role(s): {' '.join(r_fail)}\n"
     if r_had or r_fail:
         msg += "Please use !myroles to double check roles you are in and spelling\n"
+
+    if not msg:
+        msg = "I did nothing"
 
     #Message back to user
     await ctx.send(f"{member.mention}:\n{msg}")


### PR DESCRIPTION
No longer hinging off the hardcode value of "hackbot 1.1" to check where the bot should stop reporting the roles. It is now `bot.user.name`. As far as I'm aware, all bots default to getting their own names for their ranks.

Also will reverse the sequencing in which the roles are printing out to conform more to how an admin of the server sets up the roles.