### PR TITLE
Tweak uwu substitutions that weren't behaving as intended

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -74,7 +74,7 @@ json_db['uwu_suffixes'] = [
     ' （＾ｖ＾）',
     ' \*starts howling\*',
     ' \*leaps up and down\*',
-    ' \*wags tails\*',
+    ' \*wags tail\*',
 ]
 
 json_db['uwu_substitutions'] = {
@@ -82,7 +82,6 @@ json_db['uwu_substitutions'] = {
     'l': 'w',
     'the ': 'da ',
     'th': 'd',
-    'no': 'nyo',
     'hi': 'hai',
     'has': 'haz',
     'have': 'haz',
@@ -110,10 +109,9 @@ json_db['uwu_substitutions'] = {
     'you ' : 'uwu ',
     'dude': 'duwude',
     'to' : 'towo',
-    'oh' : 'owo',
     'no' : 'nowo',
+    'oh' : 'owo',
     'do ' : 'dowo ',
-    'bro' : 'browo',
 }
 
 #Write to FS


### PR DESCRIPTION
`no` translates to `nowowowo` instead of `nowo` - fixed
`bro` translates to `bwo` instead of `browo` - but I decided to keep this because there are no `r`'s in uwu
one of the suffixes was `wags tails` instead of `wags tail` - fixed