### PR TITLE
Automatically detect stock tickers in messages and display their current prices

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -196,10 +196,10 @@ async def on_message(message):
 
         output_msg += f"➝ {stock.upper()} ({js['companyName']}) - "
         if(js['extendedPrice'] is not None and not js['isUSMarketOpen']):
-          output_msg += f"Current price: ${str(js['latestPrice'])}\n"
-          output_msg += f"\t\tAfter hours price: **${str(js['extendedPrice'])}**\n"
+          output_msg += f"Current price: ${str('{:.2f}'.format(js['latestPrice']))}\n"
+          output_msg += f"\t\tAfter hours price: **${str('{:.2f}'.format(js['extendedPrice']))}**\n"
         else:
-          output_msg += f"Current price: **${str(js['latestPrice'])}**\n"
+          output_msg += f"Current price: **${str('{:.2f}'.format(js['latestPrice']))}**\n"
 
     if(num_matches == 0):
       return

--- a/bot.py
+++ b/bot.py
@@ -195,7 +195,7 @@ async def on_message(message):
         js = page.json()
 
         output_msg += f"➝ {stock.upper()} ({js['companyName']}) - "
-        if('isUSMarketOpen' in js and not js['isUSMarketOpen']):
+        if(js['extendedPrice'] is not None and not js['isUSMarketOpen']):
           output_msg += f"Current price: ${str(js['latestPrice'])}\n"
           output_msg += f"\t\tAfter hours price: **${str(js['extendedPrice'])}**\n"
         else:

--- a/bot.py
+++ b/bot.py
@@ -5,7 +5,6 @@ import ast
 import os
 import json
 import re
-import requests
 import subprocess
 
 # from dotenv import load_dotenv
@@ -164,7 +163,6 @@ async def joeis(ctx, *, arg):
     with open(json_file, 'w') as f:
         json.dump(json_db, f)
     await ctx.message.delete()
-
 
 @bot.command(pass_context=True)
 async def owo(ctx, arg1=""):

--- a/bot.py
+++ b/bot.py
@@ -110,60 +110,6 @@ json_db['uwu_substitutions'] = {
 with open(json_file, 'w') as f:
     json.dump(json_db, f)
 
-# detect stock tickers and display their current price
-@bot.listen('on_message')
-async def on_message(message):
-    max_tickers = 10 # adjusts how many tickers the bot will fetch
-    msg_str = await message.channel.fetch_message(message.id)
-    msg_str = msg_str.content
-
-    output_msg = ""
-
-    # ignore user commands, as well as responses by the bot
-    if(msg_str[0] == "!" or message.author.bot):
-        return
-
-    matches = re.finditer("\$[a-zA-Z]+", msg_str)
-    num_matches = 0
-    for match in matches:
-        if(num_matches >= max_tickers):
-            num_matches += 1
-            continue
-
-        stock = msg_str[match.start()+1:match.end()]
-        # token is publishable
-        request_url = f"https://cloud.iexapis.com/stable/stock/{stock}/quote?token=pk_b2df4f042df34774b50c5693366f8a57"
-
-        page = requests.get(request_url)
-        if(page.status_code != 200):
-            continue
-
-        if(num_matches == 0):
-            await message.add_reaction('📈')
-        num_matches += 1
-        js = page.json()
-
-        output_msg += f"➝ {stock.upper()} ({js['companyName']}) - "
-        if(js['extendedPrice'] is not None and not js['isUSMarketOpen']):
-          output_msg += f"Current price: ${str('{:.2f}'.format(js['latestPrice']))}\n"
-          output_msg += f"\t\tAfter hours price: **${str('{:.2f}'.format(js['extendedPrice']))}**\n"
-        else:
-          output_msg += f"Current price: **${str('{:.2f}'.format(js['latestPrice']))}**\n"
-
-    if(num_matches == 0):
-      return
-
-    if(num_matches > max_tickers):
-        output_msg += f"Plus {num_matches - max_tickers} more\n"
-
-    # we are not guarenteed to respond until at least this line
-
-    output_msg = "I have detected " + str(num_matches) + f" stock ticker{('s') if num_matches != 1 else ''} in your message\n\n" + output_msg
-    output_msg += "\n"
-    output_msg += "ᴡᴇ ᴅᴏ ɴᴏᴛ ɢᴜᴀʀᴀɴᴛᴇᴇ ᴛʜᴇ ᴀᴄᴄᴜʀᴀᴄʏ ᴏғ ᴛʜɪs ᴅᴀᴛᴀ"
-    channel = await discord.Client.fetch_channel(bot, message.channel.id)
-    await channel.send(output_msg)
-
 # the following code is 100% stolen from @DerpyChap on GitHub with no shame
 # https://github.com/DerpyChap/owotext/blob/master/owotext/owo.py
 class OwO:

--- a/bot.py
+++ b/bot.py
@@ -193,8 +193,9 @@ async def on_message(message):
 
         num_matches += 1
         js = page.json()
+
         output_msg += f"➝ {stock.upper()} ({js['companyName']}) - "
-        if(js['isUSMarketOpen']):
+        if('isUSMarketOpen' in js and not js['isUSMarketOpen']):
           output_msg += f"Current price: ${str(js['latestPrice'])}\n"
           output_msg += f"\t\tAfter hours price: **${str(js['extendedPrice'])}**\n"
         else:
@@ -206,7 +207,7 @@ async def on_message(message):
     # we are not guarenteed to respond until at least this line
     await message.add_reaction('📈')
 
-    output_msg = "I have detected " + str(num_matches) + f" stock ticker{('s') if num_matches != 1 else ''} in your message\n" + output_msg
+    output_msg = "I have detected " + str(num_matches) + f" stock ticker{('s') if num_matches != 1 else ''} in your message\n\n" + output_msg
     output_msg += "\n"
     output_msg += "ᴡᴇ ᴅᴏ ɴᴏᴛ ɢᴜᴀʀᴀɴᴛᴇᴇ ᴛʜᴇ ᴀᴄᴄᴜʀᴀᴄʏ ᴏғ ᴛʜɪs ᴅᴀᴛᴀ"
     channel = await discord.Client.fetch_channel(bot, message.channel.id)


### PR DESCRIPTION
Scans each message for the presence of a stock ticker in the format of `$<ticker>`, such as `$gme` or `$aapl`. The bot replies with the current price of each ticker mentioned, and if currently in after hours, it will also list that price, if supported by the stock. Invalid tickers are ignored. Bot uses the IEX Cloud API to get stock information, which apparently allows for a couple hundreds requests a *second* on the free tier. I'll note that I do have an API token hardcoded in, but it's listed as a 'publishable' token which I take to mean that it doesn't matter if other people see it. idk it's probably terrible coding practice and if that's something that can't go in the master repo I can probably figure out a way to hide it. Screenshot of functionality included

<img width="751" alt="Screen Shot 2021-02-24 at 9 44 45 PM" src="https://user-images.githubusercontent.com/12095464/109110380-dd78b680-76eb-11eb-9805-a98045c66d80.png">
