### PR TITLE
Make ban command feature-rich; Handles edge cases, too!

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -1,6 +1,7 @@
 import discord
 from discord.ext import commands
-from random import randint
+from random import randint, choice
+
 
 
 class FunCog(commands.Cog):
@@ -15,6 +16,25 @@ class FunCog(commands.Cog):
             return True
         else:
             return False
+
+    def make_ban_message(self, user_mentioned):
+        ban_messages = [
+            f"brb, banning {user_mentioned}.",
+            f"you got it, banning {user_mentioned}.",
+            f"{user_mentioned}, you must pay for your crimes. A ban shall suffice.",
+            f"today's controvesial opinion reward goes to {user_mentioned}. The prize? A ban, duh.",
+            f"{user_mentioned} gotta ban you now. Sorry.",
+            f"{user_mentioned} stop talking before you--oh, wait. Too late.",
+        ]
+        ban_easter_eggs = [
+            f"{user_mentioned} I WARNED YOU ABOUT STAIRS BRO. I TOLD YOU.",
+            f"Let's be honest with ourselves: we just wanted to ping {user_mentioned} twice.",
+            f"{user_mentioned} has broken the unspoken rule.",
+        ]
+        odds = randint(1, 1000)
+        if odds > 900:
+            return choice(ban_easter_eggs)
+        return choice(ban_messages)
 
     @commands.command()
     async def ping(self, ctx):
@@ -108,10 +128,19 @@ class FunCog(commands.Cog):
         Bans (but not actually) the person mentioned.
         If argument is an empty string, assume it was the last person talking.
         """
+        cannot_ban_bot = ctx.message.author.mention + " you can't ban me!"
+        user_attempted_bot_ban = False
 
         mentions_list = ctx.message.mentions
+        message_text = ctx.message.content
+
+        ban_has_text = False
+        if len(mentions_list) < 1 \
+        and len(message_text.split(" ")) > 1:
+            ban_has_text = True
 
         message = ""
+        user_mentioned = ""
 
         # Check that only one user is mentioned
         if len(mentions_list) > 1:
@@ -134,20 +163,62 @@ class FunCog(commands.Cog):
                 if "professors" in roles_lower:
                     message = ctx.message.author.mention + " you can't ban a professor."
                 else:
-                    message = "brb, banning " + user_mentioned.mention
+                    message = self.make_ban_message(user_mentioned.mention)
             else:
-                message = ctx.message.author.mention + " you can't ban me!"
+                user_attempted_bot_ban = True
+                message = cannot_ban_bot
         else:
-            channel = ctx.channel
-            prev_author = await channel.history(limit=2).flatten()
-            user_being_banned = prev_author[1].author
-            prev_author = prev_author[1].author.mention
-            
-            if not self.is_user_self(user_being_banned):
-                message = "brb, banning " + prev_author
+            if ban_has_text:
+                # Some users apparently want to "!ban me", "!ban you", or other edge cases.
+                # This is where we handle that.
+                message_text = ctx.message.content[5:]
+                if message_text == "me":
+                    # Person executing the command wants to be banned.
+                    user_mentioned = ctx.message.author.mention
+                    message = self.make_ban_message(ctx.message.author.mention)
+                elif message_text == "you":
+                    channel = ctx.channel
+                    prev_author = await channel.history(limit=2).flatten()
+                    user_being_banned = prev_author[1].author
+                    prev_author = prev_author[1].author.mention
+                    user_mentioned = prev_author
+
+                    if not self.is_user_self(user_being_banned):
+                        message = self.make_ban_message(prev_author)
+                    else:
+                        user_attempted_bot_ban = True
+                        message = cannot_ban_bot
+                else:
+                    # I guess we're just banning whatever now, then ¯\_(ツ)_/¯
+                    if message_text == "charon":
+                        # Unless it's the bot 🙅‍♂️
+                        user_attempted_bot_ban = True
+                        message = cannot_ban_bot
+                    else:
+                        message = self.make_ban_message(message_text)
             else:
-                message = ctx.message.author.mention + " you can't ban me!"
+                channel = ctx.channel
+                prev_author = await channel.history(limit=2).flatten()
+                user_being_banned = prev_author[1].author
+                prev_author = prev_author[1].author.mention
                 
+                if not self.is_user_self(user_being_banned):
+                    message = self.make_ban_message(prev_author)
+                else:
+                    user_attempted_bot_ban = True
+                    message = cannot_ban_bot
+
+        odds = randint(1, 100)
+        if odds > 99 and not user_attempted_bot_ban:
+            # 1 in 100 chance of getting a gif instead.
+            if user_mentioned != "":
+                await ctx.send(user_mentioned)
+                await ctx.send("https://c.tenor.com/d0VNnBZkSUkAAAAM/bongocat-banhammer.gif")
+                return
+            else:
+                await ctx.send(message_text)
+                await ctx.send("https://c.tenor.com/d0VNnBZkSUkAAAAM/bongocat-banhammer.gif")
+                return
         await ctx.send(message)
             
 


### PR DESCRIPTION
- You can now ban "me", "you", and not "charon".
- You can also just put text after the message and it'll ban that instead.
- Has some nifty easter eggs when the chances come around.
  - You'll have to look at the code to find out what the chances are.