### PR TITLE
Fixes Vaccine issues

### DIFF
--- a/cogs/info.py
+++ b/cogs/info.py
@@ -78,7 +78,8 @@ class InfoCog(commands.Cog):
         Will default to United States
         """
         url = "https://www.howmanyvaccinated.com/vaccine"
-        states_url = "https://promotions.newegg.com/EC/covid19/vaccination/vaccina.json"
+        #states_url = "https://promotions.newegg.com/EC/covid19/vaccination/vaccina.json"
+        states_url = "https://covid.cdc.gov/covid-data-tracker/COVIDData/getAjaxData?id=vaccination_data"
 
         page = requests.get(url)
         states_page = requests.get(states_url)


### PR DESCRIPTION
The previous source for vaccine info for the states was ruefully outdated. The last update was June 30th. This update changes it to the CDC's JSON data.