### PR TITLE
Fixes #90 and #10

### DIFF
--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -136,6 +136,7 @@ class RolesCog(commands.Cog):
         r_poss = []
         member = ctx.author
         br = self.bot_roles(ctx)
+        args = [sanitizeInput(i) for i in args]
 
         if "all" in args:
             for role in br:
@@ -206,6 +207,7 @@ class RolesCog(commands.Cog):
         r_poss = []
         member = ctx.author
         br = self.bot_roles(ctx)
+        args = [sanitizeInput(i) for i in args]
         if "all" in args:
             for role in br:
                 if self.has_role(ctx, role):
@@ -298,6 +300,9 @@ class RolesCog(commands.Cog):
                 sent = await ctx.reply("You can't delete that message")
                 await sent.delete(delay=5)
             await message.delete(delay=5)
+
+def sanitizeInput(s):
+    return s.strip().replace('\u200b','').lower()
 
 def setup(bot):
     bot.add_cog(RolesCog(bot))

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -148,21 +148,14 @@ class RolesCog(commands.Cog):
         else:
             #Attempt to add users roles
             levDict = {}
+            normalizedRoles = {str(i).lower() : i for i in br}
             for arg in args:
-                # Right here is where the checking would go first
-                arg = arg.lower()
-                #FIXME -- hard coded case conditions are bad code.
-                if arg == "allclass":
-                    role = discord.utils.get(ctx.guild.roles, name="allClass")
-                elif arg == "aluminum":
-                    role = discord.utils.get(ctx.guild.roles, name="Aluminum")
-                elif arg == "announcement":
-                    role = discord.utils.get(ctx.guild.roles, name="Announcement")
-                else:
-                    role = discord.utils.get(ctx.guild.roles, name=arg)
-                if role == None:
+                role = None
+                if arg.lower() not in normalizedRoles:
                     for possible in br:
                         levDict.update({possible.name : Levenshtein.distance(possible.name, arg)})
+                else:
+                    role = normalizedRoles[arg.lower()]
                 if role not in br: #Check if it's an accepted role first
                     r_fail += [arg]
                 else:
@@ -223,16 +216,15 @@ class RolesCog(commands.Cog):
                         pass #Don't care about extraneous roles
         else:
             levDict = {}
+            normalizedRoles = {str(i).lower() : i for i in br}
             for arg in args:
                 # Right here is where the checking would go first
-                arg = arg.lower()
-                if arg == "allclass":
-                    role = discord.utils.get(ctx.guild.roles, name="allClass")
-                else:
-                    role = discord.utils.get(ctx.guild.roles, name=arg)
-                if role == None:
+                role = None
+                if arg.lower() not in normalizedRoles:
                     for possible in member.roles:
                         levDict.update({possible.name : Levenshtein.distance(possible.name, arg)})
+                else:
+                    role = normalizedRoles[arg.lower()]
                 if role not in br: #Check if it's an accepted role first
                     r_fail += [arg]
 


### PR DESCRIPTION
Fixes #10 and #90

Adding and removing roles has been somewhat of a sticky issue with the bot for a while. Originally, users would have to match the case of a role letter for letter. This was then updated so that they were case insensitive, but roles with capitalization would fail to be added (e.g. `Announcement`). This update will fix #90 such that a role is now associated with it's own lower case version of the role and will be reassociated with the original word.

This update also fixes #10. Sometimes, a user will have a blank space character at the end of a role name. This will henceforth sanitize all the user's inputs so that all blank space chars are removed.

This has been tested as functional.