### PR TITLE
Real fix of get_term function

### DIFF
--- a/cogs/info.py
+++ b/cogs/info.py
@@ -212,15 +212,9 @@ class InfoCog(commands.Cog):
         # Mod can be used to change the relative term. Don't have the energy currently to implement
         today_term = datetime.now()
         add_sem = 0
-        if mod % 2 == 1:
-            mod -= 1
-            if today_term.month < 6:
-                add_sem = 6
-            else:
-                add_sem = 4
-        add_year = abs(int(mod/2))
-        coeff = 1 if mod > 0 else -1
-        term = ((today_term.year + add_year) % 2022)*10*coeff + 2222 + add_sem
+        if today_term.month > 6:
+            add_sem = 6
+        term = (today_term.year % 2022)*10 + 2222 + add_sem
         return str(term)
 
     @commands.command()


### PR DESCRIPTION
get term should now work for foreseeable future. Missed a line, this is a second try